### PR TITLE
fix: in mobile view screen size less than 768px side bar menu was not…

### DIFF
--- a/src/assets/styles/style.css
+++ b/src/assets/styles/style.css
@@ -387,6 +387,8 @@ body.fixed-nav.fixed-nav-basic.fixed-sidebar.mini-navbar.body-small .navbar-fixe
 }
 body.mini-navbar .navbar-static-side {
   width: 70px;
+  position: absolute;
+  display: block;
 }
 body.mini-navbar .profile-element,
 body.mini-navbar .nav-label,


### PR DESCRIPTION
open issue: Navbar not showing icons in responsive mode #2